### PR TITLE
Fix fixed gas price

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -92,8 +92,6 @@ export default {
     },
     xdai: {
       ...sharedNetworkConfig,
-      // Fix a gas price so that hardhat doesn't try to use EIP1559 which isn't supported on xDAI (but exposed by recent OE nodes)
-      gasPrice: 1e9,
       chainId: 100,
       url: NODE_URL || "https://xdai.poanetwork.dev",
     },


### PR DESCRIPTION
The fixed gas price was too low. Currently, the min gas price is 1.5 Gwei. We get error messages like these ones: 
https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/gekZH


I am removing the fixed gas price, as Gnosis Chain now supports eip1559. See here: https://docs.gnosischain.com/specs/hard-forks/eip-1559

Check the original PR that introduced the change
https://github.com/gnosis/gp-v2-trading-bot/pull/28