### PR TITLE
Added instructions on how to deal with the error

### DIFF
--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -63,7 +63,8 @@ export async function makeTrade(
   });
   if (tokensWithBalance.length === 0) {
     throw new Error(
-      "Account doesn't have sufficient balance in any of the provided tokens"
+      "Account doesn't have sufficient balance in any of the provided tokens.\n" +
+      `Ask the request-funding slack channel to fund the bot's account (${trader.address}).`
     );
   }
 

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -64,7 +64,7 @@ export async function makeTrade(
   if (tokensWithBalance.length === 0) {
     throw new Error(
       "Account doesn't have sufficient balance in any of the provided tokens.\n" +
-        `Ask the request-funding slack channel to fund the bot's account (${trader.address}).`
+        `Ask the request-funding slack channel to fund the bot's ${network.name} account (${trader.address}).`
     );
   }
 

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -64,7 +64,7 @@ export async function makeTrade(
   if (tokensWithBalance.length === 0) {
     throw new Error(
       "Account doesn't have sufficient balance in any of the provided tokens.\n" +
-      `Ask the request-funding slack channel to fund the bot's account (${trader.address}).`
+        `Ask the request-funding slack channel to fund the bot's account (${trader.address}).`
     );
   }
 


### PR DESCRIPTION
The bot running out of funds is probably the most common error over time.
I extended the error message with instructions on how to deal with it for the next on-call.
This seems like a more direct way to communicate that than documenting it somewhere in notion.