### PR TITLE
Brush up trading bot

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ task("trade", "Makes a random trade on GPv2 given the users balances")
   )
   .addOptionalParam(
     "apiUrl",
-    "The base API URL to use for requests (defaults to staging on the current network, i.e. https://protocol-{$network}.dev.gnosisdev.com"
+    "The base API URL to use for requests (defaults to staging on the current network)"
   )
   .addOptionalParam(
     "maxSlippageBps",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -93,7 +93,7 @@ export default {
     xdai: {
       ...sharedNetworkConfig,
       chainId: 100,
-      url: NODE_URL || "https://xdai.poanetwork.dev",
+      url: NODE_URL || "https://rpc.gnosischain.com",
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": [],
   "author": "",
   "dependencies": {
-    "@gnosis.pm/gp-v2-contracts": "1.1.2",
+    "@cowprotocol/contracts": "^1.3.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@openzeppelin/contracts": "^4.2.0",
     "@types/node-fetch": "^2.5.12",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
   "dependencies": {
     "@gnosis.pm/gp-v2-contracts": "1.1.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -340,7 +340,7 @@ async function getFirstBuyToken(
         api,
         buyToken.address,
         sellToken.address,
-        balance,
+        buyAmount,
         trader.address
       );
     } catch {

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -6,6 +6,7 @@ import {
   SigningScheme,
   EcdsaSigningScheme,
   domain,
+  Environment,
 } from "@cowprotocol/contracts";
 import {
   GPv2Settlement,
@@ -41,10 +42,7 @@ export async function makeTrade(
 ): Promise<void> {
   const [trader] = await ethers.getSigners();
   const chain = ChainUtils.fromNetwork(network);
-  const api = new Api(
-    network.name,
-    apiUrl || `https://protocol-${network.name}.dev.gnosisdev.com`
-  );
+  const api = new Api(network.name, apiUrl || Environment.Dev);
 
   console.log(`💰 Using account ${trader.address}`);
 

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -6,11 +6,11 @@ import {
   SigningScheme,
   EcdsaSigningScheme,
   domain,
-} from "@gnosis.pm/gp-v2-contracts";
+} from "@cowprotocol/contracts";
 import {
   GPv2Settlement,
   GPv2VaultRelayer,
-} from "@gnosis.pm/gp-v2-contracts/networks.json";
+} from "@cowprotocol/contracts/networks.json";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
 import { TokenInfo, TokenList } from "@uniswap/token-lists";

--- a/src/make_trade.ts
+++ b/src/make_trade.ts
@@ -188,6 +188,12 @@ async function getTradableTokens({
   const sellTokenCandidates = (
     await Promise.all(
       allTokensWithBalance.map(async ({ token, balance }) => {
+        console.log(
+          `  [DEBUG] Candidate sell token ${token.name}: ${formatAmount(
+            balance,
+            token
+          )} ${token.symbol}`
+        );
         // For randomness we shuffle the list of buy tokens
         return await getFirstBuyToken(
           token,
@@ -240,9 +246,9 @@ async function getTradableTokens({
             })) ?? Infinity;
           if (slippageBps > maxSlippageBps) {
             console.log(
-              `  [DEBUG] Selling ${token.name} for ${
+              `  [DEBUG] Cannot sell ${token.name} for ${
                 buyToken.name
-              }: Too much slippage (${(slippageBps / 100).toFixed(2)}%)`
+              }: too much slippage (${(slippageBps / 100).toFixed(2)}%)`
             );
             return null;
           }
@@ -371,6 +377,13 @@ async function getFirstBuyToken(
       );
       continue;
     }
+    console.log(
+      `  [DEBUG] Candidate trade: ${sellToken.name} for ${
+        buyToken.name
+      } (${formatAmount(sellAmount, sellToken)} ${
+        sellToken.symbol
+      } to ${formatAmount(buyAmount, buyToken)} ${buyToken.symbol})`
+    );
     return {
       token: sellToken,
       balance,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import GPv2SettlementArtefact from "@gnosis.pm/gp-v2-contracts/deployments/mainnet/GPv2Settlement.json";
+import GPv2SettlementArtefact from "@cowprotocol/contracts/deployments/mainnet/GPv2Settlement.json";
 import { HardhatEthersHelpers } from "@nomiclabs/hardhat-ethers/types";
 import ERC20 from "@openzeppelin/contracts/build/contracts/ERC20.json";
 import WethNetworks from "canonical-weth/networks.json";

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@cowprotocol/contracts@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.3.2.tgz#40b8df70965d5a8496d426a39bf4f31f9c4daa32"
+  integrity sha512-B0Z/SwrByyqGh2FcJ7kYRGxBV5iiuFlz50eCjIlFU2M+nPHLfTk/fsgLTJr4qAGaFoGHbzsOm5sd9410RmXFAw==
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -446,11 +451,6 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
-
-"@gnosis.pm/gp-v2-contracts@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.1.2.tgz#0453bb097377dc63cf46ee195f7e521d429f7e22"
-  integrity sha512-BvZMNS+fwITb+qs+trs2fyvYksa6MPjjLze9AOXPnvcKVYFEGwG6cfsecBswEMo+xevLIQNDyF7HZRhN7ply8w==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
This PR collects a few small fixes and improvements that I noticed when I was debugging the trading bot.

Right now the trading bot is not working because the `/market` endpoint is missing. This PR updates the API from the contracts to the latest version and solves the issue.

Since every change was small and I don't expect much discussion going on, I decided to bundle everything in a single PR.
You can also review each change by purpose by looking at the commits:

- [Fix xdai network URL](https://github.com/cowprotocol/trading-bot/pull/8/commits/012816f21096fc0a933dd75d3e697648bc82d73f)
- [Remove duplicate licence entry](https://github.com/cowprotocol/trading-bot/pull/8/commits/b8e7f32d1ec0bae49145b5fdea0d0a6e6fb0b814)
- [More information in logging](https://github.com/cowprotocol/trading-bot/pull/8/commits/2078b459576c581851d7122919efb1df20142780)
- [Update CoW contracts to latest version](https://github.com/cowprotocol/trading-bot/pull/8/commits/730650eddcad691ff375c4b8205f135216ece64c)
- [Fix default api URL](https://github.com/cowprotocol/trading-bot/pull/8/commits/110a5859b20f2099f618c1eb61ea54be9ae3a838)
- [Fix using sell token balance when selling the buy token](https://github.com/cowprotocol/trading-bot/pull/8/commits/47174c3b1c4584214d306a102c0cf26436ea49d7)

### Test plan

You can execute the trading bot with the usual address `0x04a66CBbA0485D7B21Af836f52b711401300FDdb`.

```
$ npx hardhat trade --network xdai --max-slippage-bps 1000 --acceptable-slippage-bps 100 
💰 Using account 0x04a66CBbA0485D7B21Af836f52b711401300FDdb
  [DEBUG] Candidate sell token Wrapped BTC on xDai: 0.00000378 WBTC
  [DEBUG] Candidate sell token Wrapped XDAI: 100.0 WXDAI
  [DEBUG] Selling Wrapped XDAI for Kyber Network Crystal on xDai: Too much slippage (41.97%)
  [DEBUG] Candidate trade: Wrapped BTC on xDai for Synthetix USD on xDai (0.00000375 WBTC to 0.090918059700724084 sUSD)
  [DEBUG] Selling Wrapped XDAI for SHE Sweatpants: Too much slippage (2.49%)
  [DEBUG] Selling Wrapped XDAI for JOON on xDai: Too much slippage (20.42%)
  [DEBUG] Selling Wrapped XDAI for Ocean Token on xDai: Too much slippage (4.69%)
  [DEBUG] Selling Wrapped XDAI for McDonaldsCoin on xDai: Too much slippage (14.88%)
  [DEBUG] Selling Wrapped XDAI for BUSD Token from BSC: Too much slippage (1.18%)
  [DEBUG] Candidate trade: Wrapped XDAI for CoW Protocol Token from Mainnet (99.998813570702295474 WXDAI to 970.198846448215494459 COW)
🤹 Selling 99.998813570702295474 of Wrapped XDAI for 965.347852215974416986 of CoW Protocol Token from Mainnet with a 0.001186429297704526 fee
```